### PR TITLE
support systemd

### DIFF
--- a/lib/itamae/plugin/recipe/god/install.rb
+++ b/lib/itamae/plugin/recipe/god/install.rb
@@ -17,11 +17,31 @@ template '/etc/god/master.conf' do
   mode '644'
 end
 
-template '/etc/init.d/god' do
-  user 'root'
-  owner 'root'
-  group 'root'
-  mode '755'
+service_variables = {
+  pid: '/var/run/god.pid',
+  config: '/etc/god/master.conf',
+  log: '/var/log/god.log',
+  log_level: 'info'
+}
+
+case "#{node.platform_family}-#{node.platform_version}"
+when /rhel-7\.(.*?)/
+  which_god = run_command('which god')
+  template '/etc/systemd/system/god.service' do
+    user 'root'
+    owner 'root'
+    group 'root'
+    mode '755'
+    variables service_variables.merge({command: which_god.stdout.chomp})
+  end
+else
+  template '/etc/init.d/god' do
+    user 'root'
+    owner 'root'
+    group 'root'
+    mode '755'
+    variables service_variables
+  end
 end
 
 template '/etc/logrotate.d/god' do

--- a/lib/itamae/plugin/recipe/god/templates/etc/init.d/god.erb
+++ b/lib/itamae/plugin/recipe/god/templates/etc/init.d/god.erb
@@ -8,16 +8,16 @@
 
 . /etc/rc.d/init.d/functions
 
-PID=/var/run/god.pid
-CONFIG=/etc/god/master.conf
-LOG=/var/log/god.log
+PID=<%= @pid %>
+CONFIG=<%= @config %>
+LOG=<%= @log %>
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RETVAL=0
 
 case "$1" in
     start)
       echo -n 'Starting god: '
-      god -P $PID -c $CONFIG -l $LOG --log-level info
+      god -P $PID -c $CONFIG -l $LOG --log-level <%= @log_level %>
       echo
       RETVAL=$?
   ;;
@@ -32,7 +32,7 @@ case "$1" in
       god quit
       echo
       echo -n 'Starting god: '
-      god -P $PID -c $CONFIG -l $LOG --log-level info
+      god -P $PID -c $CONFIG -l $LOG --log-level <%= @log_level %>
       echo
       RETVAL=$?
   ;;

--- a/lib/itamae/plugin/recipe/god/templates/etc/systemd/system/god.service.erb
+++ b/lib/itamae/plugin/recipe/god/templates/etc/systemd/system/god.service.erb
@@ -1,0 +1,11 @@
+[Unit]
+Description=God: A process monitoring framework in Ruby
+After=network.target
+
+[Service]
+PIDFile=<%= @pid %>
+ExecStart=<%= @command %> -c <%= @config %> -P <%= @pid %> -l <%= @log %> --log-level <%= @log_level %>
+ExecStop=<%= @command %> quit
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/itamae/plugin/recipe/god/version.rb
+++ b/lib/itamae/plugin/recipe/god/version.rb
@@ -2,7 +2,7 @@ module Itamae
   module Plugin
     module Recipe
       module God
-        VERSION = "0.1.0"
+        VERSION = "0.1.1"
       end
     end
   end


### PR DESCRIPTION
systemdの対応

以下のようにsystemdの設定とinit.dの設定の切り替えをおこなうようにしている。
- CentOS7の場合は、systemdの設定をおこなう
- それ以外は現状の通りinit.dの設定をおこなう